### PR TITLE
hicolor-icon-theme 0.18

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 @echo on
 
-:: nothing more to do than copy "index.theme" to the right location
+meson setup builddir --prefix=%LIBRARY_PREFIX% --backend ninja
+if errorlevel 1 exit 1
 
-md "%LIBRARY_PREFIX%\share\icons\hicolor"
-copy "index.theme" "%LIBRARY_PREFIX%\share\icons\hicolor\index.theme"
+meson install -C builddir
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-./configure --prefix=$PREFIX
-make install
+meson setup builddir --prefix=$PREFIX
+meson install -C builddir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,6 @@ source:
 
 build:
   number: 0
-  # it would be nice if this were noarch: generic because it just installs some files,
-  # but we want them in $PREFIX on Unix and %LIBRARY_PREFIX% on Windows
-  # noarch: generic
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   build:
-    - ninja
+    - ninja-base
     - pkg-config
   host:
     - meson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,9 @@ build:
 
 requirements:
   build:
-    - make  # [unix]
+    - meson
+    - ninja
+    - pkg-config
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.18" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hicolor-icon-theme" %}
-{% set version = "0.17" %}
+{% set version = "0.18" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://icon-theme.freedesktop.org/releases/{{ name }}-{{ version }}.tar.xz
-  sha256: 317484352271d18cbbcfac3868eab798d67fff1b8402e740baa6ff41d588a9d8
+  sha256: db0e50a80aa3bf64bb45cbca5cf9f75efd9348cf2ac690b907435238c3cf81d7
 
 build:
-  number: 2
+  number: 0
   # it would be nice if this were noarch: generic because it just installs some files,
   # but we want them in $PREFIX on Unix and %LIBRARY_PREFIX% on Windows
   # noarch: generic
@@ -29,7 +29,7 @@ about:
   license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING
-  summary: 'Fallback theme for FreeDesktop.org icon themes'
+  summary: Fallback theme for FreeDesktop.org icon themes
   description: |
     This is the default fallback theme used by implementations of the icon
     theme specification.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,10 @@ build:
 
 requirements:
   build:
-    - meson
     - ninja
     - pkg-config
+  host:
+    - meson
 
 test:
   commands:
@@ -39,6 +40,7 @@ about:
     The specification is availible at:
     http://www.freedesktop.org/standards/icon-theme-spec/
   dev_url: https://gitlab.freedesktop.org/xdg/default-icon-theme
+  doc_url: https://specifications.freedesktop.org/icon-theme/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-16248
- Project Dev URL: https://gitlab.freedesktop.org/xdg/default-icon-theme
- conda-forge feedstock: https://github.com/conda-forge/hicolor-icon-theme-feedstock

## Changes
- Bump version 0.17 -> 0.18, update sha256, reset build number to 0
- Port build.sh/bld.bat from autotools to Meson (upstream 0.18 dropped ./configure entirely)
- Update build requirements: remove `make`, add `meson`, `ninja`, `pkg-config`

## Notes
- Upstream 0.18 release notes: "Port build system to Meson." The tarball no longer ships a configure script, so the old build.sh/bld.bat would fail outright against this version.
- conda-forge's feedstock is still on 0.17 (autotools), so it wasn't usable as a reference for the build-system migration.